### PR TITLE
Center images

### DIFF
--- a/assets/scss/article.scss
+++ b/assets/scss/article.scss
@@ -452,6 +452,10 @@
     padding: 160px 0 35px;
 }
 
+.post-content > img, .post-content > figure{
+    text-align: center;
+}
+
 /**************************************ARTICLE NEXT**************************************/
 
 .footer-next-heading{


### PR DESCRIPTION
In the article all images except hero image are left align, this looks weird on desktop pc. The correction applied to css element img and Hugo shortcode figure.